### PR TITLE
Spit bug fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,76 @@
+*.swp
+*.swo
+compile
+
+# /
+/Makefile
+/config.log
+/config.status
+/tags
+/TAGS
+/.svn
+
+# /dat/
+/dat/Makefile
+/dat/*.lev
+/dat/data
+/dat/dungeon.pdf
+/dat/dungeon
+/dat/ghdat
+/dat/options
+/dat/oracles
+/dat/quest.dat
+/dat/quest_levs
+/dat/rumors
+/dat/spec_levs
+/dat/vaults.dat
+/dat/pet_mark.xbm
+/dat/rip.xpm
+/dat/x11tiles
+
+
+# /doc/
+/doc/Makefile
+/doc/Guidebook
+
+# /include/
+/include/autoconf.h
+/include/autoconf_paths.h
+/include/date.h
+/include/dgn_comp.h
+/include/lev_comp.h
+/include/onames.h
+/include/pm.h
+/include/tile.h
+/include/vis_tab.h
+/include/win32api.h
+
+# /src/
+/src/*.o
+/src/nhwin.a
+/src/grunthack
+/src/Makefile
+/src/Sysunix
+/src/config.h-t
+/src/hack.h-t
+/src/vis_tab.c
+/src/monstr.c
+/src/tile.c
+
+# /util/
+/util/*.o
+/util/Makefile
+/util/dgn_comp
+/util/dgn_lex.c
+/util/dgn_yacc.c
+/util/dlb
+/util/lev_comp
+/util/lev_lex.c
+/util/lev_yacc.c
+/util/makedefs
+/util/recover
+/util/tile2x11
+/util/tilemap
+
+# /win/
+/win/*/*.o

--- a/src/mthrowu.c
+++ b/src/mthrowu.c
@@ -1136,13 +1136,13 @@ register struct attack *mattk;
 			otmp = mksobj(ACID_VENOM, TRUE, FALSE);
 			break;
 		}
-		if(!rn2(BOLT_LIM-distmin(mtmp->mx,mtmp->my,mtmp->mux,mtmp->muy))) {
+		if(!rn2(BOLT_LIM-distmin(mtmp->mx,mtmp->my,mdef->mx,mdef->my))) {
 		    if (canseemon(mtmp)) {
 			pline("%s spits venom!", Monnam(mtmp));
 		    nomul(0);
 		    }
 		    m_throw(mtmp, mtmp->mx, mtmp->my, sgn(tbx), sgn(tby),
-			distmin(mtmp->mx,mtmp->my,mtmp->mux,mtmp->muy), otmp,
+			distmin(mtmp->mx,mtmp->my,mdef->mx,mdef->my), otmp,
 			FALSE);
 		    return 0;
 		}

--- a/src/rnd.c
+++ b/src/rnd.c
@@ -22,16 +22,12 @@ int
 rn2(x)		/* 0 <= rn2(x) < x */
 register int x;
 {
-#ifdef DEBUG
 	if (x <= 0) {
 		impossible("rn2(%d) attempted", x);
 		return(0);
 	}
 	x = RND(x);
 	return(x);
-#else
-	return(RND(x));
-#endif
 }
 
 #endif /* OVL0 */


### PR DESCRIPTION
Fixes bug where monsters spitting venom could cause game to crash.
Crash was caused by passing incorrect value to rn2(), which was sometimes zero.
Additionally, the #ifdef DEBUG in rn2() has been removed so that any future issues like this will be caught by the impossible() instead of crashing.
Also added a .gitignore for convenience, though this is not related to the specific issue.